### PR TITLE
add otel-sidecar templates for llm-service

### DIFF
--- a/Dynatrace/deploy/helm/llm-service/templates/inference-service.yaml
+++ b/Dynatrace/deploy/helm/llm-service/templates/inference-service.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     opendatahub.io/dashboard: "true"
     networking.knative.dev/visibility: "cluster-local"
+    sidecar.opentelemetry.io/inject: {{ $key }}-otelsidecar
 spec:
   predictor:
     maxReplicas: 1

--- a/Dynatrace/deploy/helm/llm-service/templates/llm-serve-otc-secret.yaml
+++ b/Dynatrace/deploy/helm/llm-service/templates/llm-serve-otc-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dynatrace-otc-secret
+type: Opaque
+stringData:
+  endpoint: {{ .Values.dynatrace.endpoint }}
+  apiToken: {{ .Values.dynatrace.apiToken }}

--- a/Dynatrace/deploy/helm/llm-service/templates/llm-serve-otc-sidecar.yaml
+++ b/Dynatrace/deploy/helm/llm-service/templates/llm-serve-otc-sidecar.yaml
@@ -1,0 +1,66 @@
+{{- $root := . }}
+{{- range $key, $model := $.Values.models }}
+{{- if $model.enabled }}
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: {{ $key }}-otelsidecar
+spec:
+  mode: sidecar
+  env:
+    - name: DYNATRACE_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: dynatrace-otc-secret
+          key: endpoint
+    - name: DYNATRACE_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: dynatrace-otc-secret
+          key: apiToken
+  config:
+    exporters:
+      debug:
+        verbosity: detailed
+      otlphttp/dynatrace:
+        endpoint: ${DYNATRACE_ENDPOINT}
+        headers:
+          Authorization: Api-Token ${DYNATRACE_API_TOKEN}
+    processors:
+      batch:
+        send_batch_size: 100
+        timeout: 1s
+      cumulativetodelta: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 95
+        spike_limit_percentage: 25
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: '0.0.0.0:4317'
+          http:
+            endpoint: '0.0.0.0:4318'
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: {{ $key }}-serve
+              scrape_interval: 10s
+              static_configs:
+                - targets:
+                    - 'localhost:8000'
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlphttp/dynatrace
+            - debug
+          processors:
+            - memory_limiter
+            - cumulativetodelta
+            - batch
+          receivers:
+            - prometheus
+{{- end }}
+{{- end }}

--- a/Dynatrace/deploy/helm/llm-service/values-dynatrace-secret.yaml
+++ b/Dynatrace/deploy/helm/llm-service/values-dynatrace-secret.yaml
@@ -1,0 +1,3 @@
+dynatrace:
+  endpoint: "https://rpr13334.live.dynatrace.com/api/v2/otlp"  # Replace with your actual endpoint
+  apiToken: "your-api-token-here"  # Replace with your actual API token


### PR DESCRIPTION
I didn't add many values to the template, mostly hard-coded for now.
It made sense to add the sidecar templates alongside the llm-service templates (not in the otel-collector folder) 
I have not tested these, we'll do that tomorrow :) 